### PR TITLE
Adds support to Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/support": "5.5.*",
-        "illuminate/console": "5.5.*",
+        "illuminate/support": "5.5.*|5.6.*",
+        "illuminate/console": "5.5.*|5.6.*",
         "themsaid/forge-sdk": "^1.2",
         "ohdearapp/ohdear-php-sdk": "0.*"
     },


### PR DESCRIPTION
This PR makes `laravel-forge-sync` compatible with Laravel 5.6.